### PR TITLE
[main][feat] Add increase lock amount function

### DIFF
--- a/contracts/8.7/xALPACA.sol
+++ b/contracts/8.7/xALPACA.sol
@@ -55,8 +55,8 @@ contract xALPACA is ReentrancyGuard {
   /// @dev Constants
   uint256 public constant ACTION_DEPOSIT_FOR = 0;
   uint256 public constant ACTION_CREATE_LOCK = 1;
-  uint256 public constant INCREASE_LOCK_AMOUNT = 2;
-  uint256 public constant INCREASE_UNLOCK_TIME = 3;
+  uint256 public constant ACTION_INCREASE_LOCK_AMOUNT = 2;
+  uint256 public constant ACTION_INCREASE_UNLOCK_TIME = 3;
 
   uint256 public constant WEEK = 7 days;
   uint256 public constant MAX_LOCK = 4 * 365 days;
@@ -458,6 +458,18 @@ contract xALPACA is ReentrancyGuard {
       }
     }
     return _min;
+  }
+
+  /// @notice Increase lock amount without increase "end"
+  /// @param _amount The amount of ALPACA to be added to the lock
+  function increaseLockAmount(uint256 _amount) external nonReentrant {
+    LockedBalance memory _lock = LockedBalance({ amount: locks[msg.sender].amount, end: locks[msg.sender].end });
+
+    require(_amount > 0, "bad _amount");
+    require(_lock.amount > 0, "!lock existed");
+    require(_lock.end > block.timestamp, "lock expired. withdraw please");
+
+    _depositFor(msg.sender, _amount, 0, _lock, ACTION_INCREASE_LOCK_AMOUNT);
   }
 
   /// @notice Round off random timestamp to week


### PR DESCRIPTION
## Description
Add increase lock amount function to allow users to increase the lock amount without changing lock period.

## Why?
Previously users only have an ability to create lock and cannot alter anything else. This PR will enable users to increase lock amount while holding the lock.
