### PR TITLE
[main][fix] Change MAX_LOCK revert message

### DIFF
--- a/contracts/8.7/xALPACA.sol
+++ b/contracts/8.7/xALPACA.sol
@@ -382,7 +382,7 @@ contract xALPACA is Initializable, ReentrancyGuardUpgradeable, OwnableUpgradeabl
     require(_amount > 0, "bad amount");
     require(_locked.amount == 0, "already lock");
     require(_unlockTime > block.timestamp, "can only lock until future");
-    require(_unlockTime <= block.timestamp + MAX_LOCK, "can only lock 4 years max");
+    require(_unlockTime <= block.timestamp + MAX_LOCK, "can only lock 1 year max");
 
     _depositFor(msg.sender, _amount, _unlockTime, _locked, ACTION_CREATE_LOCK);
   }
@@ -503,7 +503,7 @@ contract xALPACA is Initializable, ReentrancyGuardUpgradeable, OwnableUpgradeabl
     require(_lock.amount > 0, "!lock existed");
     require(_lock.end > block.timestamp, "lock expired. please withdraw");
     require(_newUnlockTime > _lock.end, "only extend lock");
-    require(_newUnlockTime <= block.timestamp + MAX_LOCK, "4 years max");
+    require(_newUnlockTime <= block.timestamp + MAX_LOCK, "1 year max");
 
     _depositFor(msg.sender, 0, _newUnlockTime, _lock, ACTION_INCREASE_UNLOCK_TIME);
   }

--- a/tests/xALPACA.test.ts
+++ b/tests/xALPACA.test.ts
@@ -166,7 +166,7 @@ describe("xALPACA", () => {
       it("should revert", async () => {
         await expect(
           xALPACA.createLock("1", (await timeHelpers.latestTimestamp()).add(MAX_LOCK.add(WEEK)))
-        ).to.be.revertedWith("can only lock 4 years max");
+        ).to.be.revertedWith("can only lock 1 year max");
       });
     });
 
@@ -371,7 +371,7 @@ describe("xALPACA", () => {
       });
     });
 
-    context("when new unlock time after than 4 years", async () => {
+    context("when new unlock time after than 1 year", async () => {
       it("should revert", async () => {
         const lockAmount = ethers.utils.parseEther("10");
         await ALPACAasAlice.approve(xALPACA.address, ethers.constants.MaxUint256);
@@ -382,10 +382,10 @@ describe("xALPACA", () => {
         // Alice create lock with expire in 1 week
         await xALPACAasAlice.createLock(lockAmount, (await timeHelpers.latestTimestamp()).add(WEEK));
 
-        // Alice try to increaseUnlockTime to more than 4 years, this should revert
+        // Alice try to increaseUnlockTime to more than 1 year, this should revert
         await expect(
           xALPACAasAlice.increaseUnlockTime((await timeHelpers.latestTimestamp()).add(MAX_LOCK).add(WEEK))
-        ).to.be.revertedWith("4 years max");
+        ).to.be.revertedWith("1 year max");
       });
     });
 


### PR DESCRIPTION
## Description
Change message related to max_lock from 4 years -> 1 year

## Why?
Per https://github.com/alpaca-finance/xALPACA-contract/pull/9, we change the value but didn't change the revert message regarding that.

## ChangeLogs:
Replace "4 years" -> "1 year" in contract and test.

