### PR TITLE
[main][feat] Add Gateway contract to claim multiple reward in one tx 

### DIFF
--- a/contracts/8.7/GrassHouseGateway.sol
+++ b/contracts/8.7/GrassHouseGateway.sol
@@ -17,17 +17,9 @@ import "./interfaces/IGrassHouse.sol";
 
 /// @title GrassHouseGateway
 contract GrassHouseGateway {
-  /// @notice Libraries
-
-  /// @notice Events
-
-  /// @notice State
-
-  /// @notice Attributes for Gateway
-
   function claimMultiple(address[] calldata _grassHouses, address _for) external {
     for (uint256 i = 0; i < _grassHouses.length; i++) {
-      IGrassHouse(_grassHouses[i]).claim();
+      IGrassHouse(_grassHouses[i]).claim(_for);
     }
   }
 }

--- a/contracts/8.7/GrassHouseGateway.sol
+++ b/contracts/8.7/GrassHouseGateway.sol
@@ -14,6 +14,7 @@ Alpaca Fin Corporation
 pragma solidity 0.8.7;
 
 import "./interfaces/IGrassHouse.sol";
+
 /// @title GrassHouseGateway
 contract GrassHouseGateway {
   /// @notice Libraries
@@ -21,10 +22,12 @@ contract GrassHouseGateway {
   /// @notice Events
 
   /// @notice State
-  
+
   /// @notice Attributes for Gateway
 
   function claimMultiple(address[] calldata _grassHouses, address _for) external {
-    require(false, "test");
+    for (uint256 i = 0; i < _grassHouses.length; i++) {
+      IGrassHouse(_grassHouses[i]).claim();
+    }
   }
 }

--- a/contracts/8.7/GrassHouseGateway.sol
+++ b/contracts/8.7/GrassHouseGateway.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+**/
+
+pragma solidity 0.8.7;
+
+import "./interfaces/IGrassHouse.sol";
+/// @title GrassHouseGateway
+contract GrassHouseGateway {
+  /// @notice Libraries
+
+  /// @notice Events
+
+  /// @notice State
+  
+  /// @notice Attributes for Gateway
+
+  function claimMultiple(address[] calldata _grassHouses, address _for) external {
+    require(false, "test");
+  }
+}

--- a/contracts/8.7/interfaces/IGrassHouse.sol
+++ b/contracts/8.7/interfaces/IGrassHouse.sol
@@ -16,4 +16,5 @@ pragma solidity 0.8.7;
 interface IGrassHouse {
   function rewardToken() external returns (address);
   function feed(uint256 _amount) external returns (bool);
+  function claim(address _for) external returns (uint256);
 }

--- a/contracts/8.7/mocks/MockGrassHouse.sol
+++ b/contracts/8.7/mocks/MockGrassHouse.sol
@@ -23,16 +23,26 @@ import "../SafeToken.sol";
 contract MockGrassHouse is IGrassHouse {
   using SafeToken for address;
   address public override rewardToken;
+  uint256 public rewardPerClaim;
 
   /// @notice Constructor to instaniate MockGrassHouse
   /// @param _rewardToken The token to be distributed
   constructor(address _rewardToken) {
     rewardToken = _rewardToken;
+    rewardPerClaim = 0;
   }
 
   /// @notice Receive rewardTokens into the contract and trigger token checkpoint
   function feed(uint256 _amount) external override returns (bool) {
     rewardToken.safeTransferFrom(msg.sender, address(this), _amount);
     return true;
+  }
+
+  function setRewardPerClaim(uint256 _amount) external {
+    rewardPerClaim = _amount;
+  }
+
+  function claim(address _for) external override returns (uint256) {
+    rewardToken.safeTransfer(_for, rewardPerClaim);
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "hardhat test",
     "integration-test": "hardhat test --config hardhat.config.forking.ts",
     "test:feeder": "hardhat test ./tests/unit/AlpacaFeeder.test.ts",
+    "test:gateway": "hardhat test ./tests/unit/GrassHouseGateway.test.ts",
     "test:xAlpaca": "hardhat test ./tests/unit/xALPACA.test.ts",
     "test:grassHouse": "hardhat test ./tests/unit/GrassHouse.test.ts",
     "testnet": "hardhat console --no-compile --network testnet",

--- a/tests/unit/GrassHouseGateway.test.ts
+++ b/tests/unit/GrassHouseGateway.test.ts
@@ -1,0 +1,67 @@
+import { ethers, waffle, upgrades } from "hardhat";
+import { Signer, BigNumber } from "ethers";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import {
+  BEP20,
+  BEP20__factory,
+  MockGrassHouse,
+  MockGrassHouse__factory,
+  MockProxyToken,
+  MockProxyToken__factory,
+  GrassHouseGateway,
+  GrassHouseGateway__factory
+} from "../../typechain";
+
+chai.use(solidity);
+const { expect } = chai;
+
+describe("AlpacaFeeder", () => {
+  // Constants
+  const FAIR_LAUNCH_POOL_ID = 123;
+
+  // Contact Instance
+  let alpaca: BEP20;
+  let proxyToken: MockProxyToken;
+
+  let grassHouse: MockGrassHouse;
+
+  // Accounts
+  let deployer: Signer;
+  let alice: Signer;
+
+  let deployerAddress: string;
+  let aliceAddress: string;
+
+  // Contract Signer
+  let alpacaAsAlice: BEP20;
+
+  async function fixture() {
+    [deployer, alice] = await ethers.getSigners();
+    [deployerAddress, aliceAddress] = await Promise.all([deployer.getAddress(), alice.getAddress()]);
+
+    // Deploy ALPACA
+    const BEP20 = (await ethers.getContractFactory("BEP20", deployer)) as BEP20__factory;
+    alpaca = await BEP20.deploy("ALPACA", "ALPACA");
+
+    // Deploy GrassHouse
+    const MockGrassHouse = (await ethers.getContractFactory("MockGrassHouse", deployer)) as MockGrassHouse__factory;
+    grassHouse = await MockGrassHouse.deploy(alpaca.address);
+
+    // MINT
+    await alpaca.mint(deployerAddress, ethers.utils.parseEther("8888888"));
+    await alpaca.mint(aliceAddress, ethers.utils.parseEther("8888888"));
+
+    // Assign contract signer
+    alpacaAsAlice = BEP20__factory.connect(alpaca.address, alice);
+  }
+
+  beforeEach(async () => {
+    await waffle.loadFixture(fixture);
+  });
+
+  describe("#initialize", () => {
+    it("should initialized correctly", async () => {
+    });
+  });
+});

--- a/tests/unit/GrassHouseGateway.test.ts
+++ b/tests/unit/GrassHouseGateway.test.ts
@@ -22,9 +22,13 @@ describe("AlpacaFeeder", () => {
 
   // Contact Instance
   let alpaca: BEP20;
+  let rewardToken: BEP20;
   let proxyToken: MockProxyToken;
 
   let grassHouse: MockGrassHouse;
+  let secondGrasshouse: MockGrassHouse;
+  let gateway: GrassHouseGateway;
+
 
   // Accounts
   let deployer: Signer;
@@ -34,7 +38,11 @@ describe("AlpacaFeeder", () => {
   let aliceAddress: string;
 
   // Contract Signer
-  let alpacaAsAlice: BEP20;
+  let alpacaAsDeployer: BEP20;
+
+  let rewardTokenAsDeployer: BEP20;
+
+  let gatewayAsAlice: GrassHouseGateway;
 
   async function fixture() {
     [deployer, alice] = await ethers.getSigners();
@@ -43,25 +51,73 @@ describe("AlpacaFeeder", () => {
     // Deploy ALPACA
     const BEP20 = (await ethers.getContractFactory("BEP20", deployer)) as BEP20__factory;
     alpaca = await BEP20.deploy("ALPACA", "ALPACA");
+    rewardToken = await BEP20.deploy("RTOKEN", "RTOKEN");
 
     // Deploy GrassHouse
     const MockGrassHouse = (await ethers.getContractFactory("MockGrassHouse", deployer)) as MockGrassHouse__factory;
     grassHouse = await MockGrassHouse.deploy(alpaca.address);
+    secondGrasshouse = await MockGrassHouse.deploy(rewardToken.address);
+
+    // Deploy Gateway
+    const Gateway = (await ethers.getContractFactory("GrassHouseGateway", deployer)) as GrassHouseGateway__factory;
+    gateway = await Gateway.deploy();
 
     // MINT
     await alpaca.mint(deployerAddress, ethers.utils.parseEther("8888888"));
-    await alpaca.mint(aliceAddress, ethers.utils.parseEther("8888888"));
+    await rewardToken.mint(deployerAddress, ethers.utils.parseEther("8888888"));
 
     // Assign contract signer
-    alpacaAsAlice = BEP20__factory.connect(alpaca.address, alice);
+    alpacaAsDeployer = BEP20__factory.connect(alpaca.address, deployer);
+    rewardTokenAsDeployer = BEP20__factory.connect(rewardToken.address, deployer);
+
+    gatewayAsAlice = GrassHouseGateway__factory.connect(gateway.address, alice);
+
+    // Set Mock Grasshouse to release 10 alpaca per claim
+    grassHouse.setRewardPerClaim(ethers.utils.parseEther("10"));
+    secondGrasshouse.setRewardPerClaim(ethers.utils.parseEther("20"));
+
+    // Transfer tokens to Grasshouse
+    alpacaAsDeployer.transfer(grassHouse.address, ethers.utils.parseEther("100"));
+    rewardTokenAsDeployer.transfer(secondGrasshouse.address, ethers.utils.parseEther("100"));
   }
 
   beforeEach(async () => {
     await waffle.loadFixture(fixture);
   });
 
-  describe("#initialize", () => {
-    it("should initialized correctly", async () => {
-    });
+  describe("#Claim", () => {
+    context("if all addresses are grasshouses", async () => {
+      it("should be able to claim through gateway", async () => {
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(0);
+
+        await gatewayAsAlice.claimMultiple([grassHouse.address, secondGrasshouse.address], await alice.getAddress());
+
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(ethers.utils.parseEther("10"));
+        expect(await rewardToken.balanceOf(await alice.getAddress())).to.be.eq(ethers.utils.parseEther("20"));
+      });
+    })
+
+    context("if some addresses are not grasshouses", async () => {
+      it("should revert", async () => {
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(0);
+
+        await expect(gatewayAsAlice.claimMultiple([grassHouse.address, alpaca.address], await alice.getAddress())).to.be.reverted;
+
+        
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(0);
+        expect(await rewardToken.balanceOf(await alice.getAddress())).to.be.eq(0);
+      });
+    })
+
+    context("if no addresses are provided", async () => {
+      it("should be ok", async () => {
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(0);
+
+        await expect(gatewayAsAlice.claimMultiple([], await alice.getAddress())).to.not.be.reverted;
+        
+        expect(await alpaca.balanceOf(await alice.getAddress())).to.be.eq(0);
+        expect(await rewardToken.balanceOf(await alice.getAddress())).to.be.eq(0);
+      });
+    })
   });
 });

--- a/tests/unit/GrassHouseGateway.test.ts
+++ b/tests/unit/GrassHouseGateway.test.ts
@@ -16,19 +16,14 @@ import {
 chai.use(solidity);
 const { expect } = chai;
 
-describe("AlpacaFeeder", () => {
-  // Constants
-  const FAIR_LAUNCH_POOL_ID = 123;
-
+describe("GrasshouseGateway", () => {
   // Contact Instance
   let alpaca: BEP20;
   let rewardToken: BEP20;
-  let proxyToken: MockProxyToken;
 
   let grassHouse: MockGrassHouse;
   let secondGrasshouse: MockGrassHouse;
   let gateway: GrassHouseGateway;
-
 
   // Accounts
   let deployer: Signer;
@@ -39,7 +34,6 @@ describe("AlpacaFeeder", () => {
 
   // Contract Signer
   let alpacaAsDeployer: BEP20;
-
   let rewardTokenAsDeployer: BEP20;
 
   let gatewayAsAlice: GrassHouseGateway;


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Support Claim All functionality

## Why?
Current architecture doesn't support claim all grasshouses

## ChangeLogs:
- Add GrassHouseGateway contract that acts as an proxy to interact with underlying grasshouses

